### PR TITLE
bumped toolchain-gccarmnoneeabi from 1.70201.0 to 1.120301.0

### DIFF
--- a/platform.json
+++ b/platform.json
@@ -43,7 +43,7 @@
     "toolchain-gccarmnoneeabi": {
       "type": "toolchain",
       "owner": "platformio",
-      "version": "~1.70201.0",
+      "version": "~1.120301.0",
       "optionalVersions": [
         ">=1.40803.0,<1.40805.0",
         ">=1.60301.0,<1.80000.0",


### PR DESCRIPTION
See: https://github.com/hmueller01/pubsubclient3/issues/6

There was an issue with [pubsubclient3](https://github.com/hmueller01/pubsubclient3) regarding an incompatible macro when `#include <functional>` was used.